### PR TITLE
[Exercise 2] Nguyen Thanh Phuc

### DIFF
--- a/app/src/test/java/com/sun/training/ut/ExerciseTwoTest.kt
+++ b/app/src/test/java/com/sun/training/ut/ExerciseTwoTest.kt
@@ -22,7 +22,7 @@ class ExerciseTwoTest {
     }
 
     @Test
-    fun calculateFee_VipMember() {
+    fun calculateFee_VipMember_Return0() {
         viewModel.apply {
             onTimeChanged(8, 10)
             onDateChanged(26, 10)
@@ -33,7 +33,7 @@ class ExerciseTwoTest {
     }
 
     @Test
-    fun calculateFee_NormalDay_WorkingHour_NonVipMember() {
+    fun calculateFee_NormalDay_WorkingHour_NonVipMember_Return0() {
         viewModel.apply {
             onTimeChanged(9, 10)
             onDateChanged(26, 10)
@@ -44,7 +44,7 @@ class ExerciseTwoTest {
     }
 
     @Test
-    fun calculateFee_NormalDay_NotWorkingHour_NonVipMember() {
+    fun calculateFee_NormalDay_NotWorkingHour_NonVipMember_Return110() {
         viewModel.apply {
             onTimeChanged(19, 30)
             onDateChanged(26, 10)
@@ -55,7 +55,7 @@ class ExerciseTwoTest {
     }
 
     @Test
-    fun calculateFee_Holidays_WorkingHour_NonVipMember() {
+    fun calculateFee_Holidays_WorkingHour_NonVipMember_Return110() {
         viewModel.apply {
             onTimeChanged(9, 30)
             onDateChanged(2, 8)
@@ -66,10 +66,21 @@ class ExerciseTwoTest {
     }
 
     @Test
-    fun calculateFee_Holidays_NotWorkingHour_NonVipMember() {
+    fun calculateFee_Holidays_NotWorkingHour_NonVipMember_Return110() {
         viewModel.apply {
             onTimeChanged(22, 30)
             onDateChanged(2, 8)
+            onVipChecked(false)
+            calculateFee()
+        }
+        Assert.assertEquals(Constant.FEE_110, viewModel.feeLiveData.value)
+    }
+
+    @Test
+    fun calculateFee_NormalDay_WorkingHourEqual845_NonVipMember_Return110() {
+        viewModel.apply {
+            onTimeChanged(8, 45)
+            onDateChanged(26, 10)
             onVipChecked(false)
             calculateFee()
         }

--- a/app/src/test/java/com/sun/training/ut/ExerciseTwoTest.kt
+++ b/app/src/test/java/com/sun/training/ut/ExerciseTwoTest.kt
@@ -1,0 +1,78 @@
+package com.sun.training.ut
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.sun.training.ut.data.Constant
+import com.sun.training.ut.ui.exercise_two.ExerciseTwoViewModel
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+
+class ExerciseTwoTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    lateinit var viewModel: ExerciseTwoViewModel
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        viewModel = ExerciseTwoViewModel()
+    }
+
+    @Test
+    fun calculateFee_VipMember() {
+        viewModel.apply {
+            onTimeChanged(8, 10)
+            onDateChanged(26, 10)
+            onVipChecked(true)
+            calculateFee()
+        }
+        Assert.assertEquals(0, viewModel.feeLiveData.value)
+    }
+
+    @Test
+    fun calculateFee_NormalDay_WorkingHour_NonVipMember() {
+        viewModel.apply {
+            onTimeChanged(9, 10)
+            onDateChanged(26, 10)
+            onVipChecked(false)
+            calculateFee()
+        }
+        Assert.assertEquals(0, viewModel.feeLiveData.value)
+    }
+
+    @Test
+    fun calculateFee_NormalDay_NotWorkingHour_NonVipMember() {
+        viewModel.apply {
+            onTimeChanged(19, 30)
+            onDateChanged(26, 10)
+            onVipChecked(false)
+            calculateFee()
+        }
+        Assert.assertEquals(Constant.FEE_110, viewModel.feeLiveData.value)
+    }
+
+    @Test
+    fun calculateFee_Holidays_WorkingHour_NonVipMember() {
+        viewModel.apply {
+            onTimeChanged(9, 30)
+            onDateChanged(2, 8)
+            onVipChecked(false)
+            calculateFee()
+        }
+        Assert.assertEquals(Constant.FEE_110, viewModel.feeLiveData.value)
+    }
+
+    @Test
+    fun calculateFee_Holidays_NotWorkingHour_NonVipMember() {
+        viewModel.apply {
+            onTimeChanged(22, 30)
+            onDateChanged(2, 8)
+            onVipChecked(false)
+            calculateFee()
+        }
+        Assert.assertEquals(Constant.FEE_110, viewModel.feeLiveData.value)
+    }
+}


### PR DESCRIPTION
◎Exercise
--
Khi sử dụng ATM của ngân hàng Việt Nam, phí rút tiền từ ATM sẽ thay đổi theo các điều kiện dưới đây:
---
●Điều kiện tiên quyết：
①：Ngày thường từ 0:00～8:44, phí là 110円/yên.
②：Ngày thường từ 8:45～17:59, phí là 0円/yên.
③：Ngày thường từ 18:00～23:59, phí là 110円/yên.
④：Thứ 7, chủ nhật, ngày nghỉ lễ phí cho tất cả các khung giờ là 110円/yên.
⑤：Khách hàng đáp ứng các tiêu chí đặc thù (khách vip) , phí là 0円/yên.
⑥：Điều kiện được ưu tiên cao nhất là "Khách hàng đáp ứng các tiêu chí đặc thù (khách vip) , phí là 0円/yên".

![image](https://user-images.githubusercontent.com/69672331/115674828-3d9c7980-a378-11eb-94b0-18d698af04a2.png)
